### PR TITLE
Fix code scanning alert no. 2: SQL query built from user-controlled sources

### DIFF
--- a/app.py
+++ b/app.py
@@ -54,15 +54,12 @@ class UserResource(Resource):
 
 
        try:
-           # Directly incorporating user input into the SQL query
-           rawQueryString = f"SELECT * FROM user WHERE id = {id}"
-           query = text(rawQueryString)
+           # Using parameterized query to prevent SQL injection
+           query = text("SELECT * FROM user WHERE id = :id")
 
-
-           # Execute the vulnerable query
-           result = db.session.execute(query)
+           # Execute the safe query with parameter
+           result = db.session.execute(query, {'id': id})
            user = result.fetchall()
-
 
            if user:
                return user


### PR DESCRIPTION
Fixes [https://github.com/GitHub-PaloIT-Lab/excitement-day-examples/security/code-scanning/2](https://github.com/GitHub-PaloIT-Lab/excitement-day-examples/security/code-scanning/2)

To fix the problem, we need to use SQLAlchemy's parameterized queries to safely embed the user-provided `id` into the SQL query. This approach ensures that the input is properly escaped and prevents SQL injection attacks.

- Replace the raw SQL query string with a parameterized query.
- Use SQLAlchemy's `text` function with bind parameters to safely include the user input in the query.
- Modify the `get` method in the `UserResource` class to use the parameterized query.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
