### PR TITLE
Fix code scanning alert no. 1: Flask app is run in debug mode

### DIFF
--- a/app.py
+++ b/app.py
@@ -81,6 +81,8 @@ def api_spec():
 
 
 if __name__ == '__main__':
+   import os
    with app.app_context():
        db.create_all()
-   app.run(debug=True, port=4000)
+   debug_mode = os.getenv('FLASK_DEBUG', 'False').lower() in ['true', '1', 't']
+   app.run(debug=debug_mode, port=4000)


### PR DESCRIPTION
Fixes [https://github.com/GitHub-PaloIT-Lab/excitement-day-examples/security/code-scanning/1](https://github.com/GitHub-PaloIT-Lab/excitement-day-examples/security/code-scanning/1)

To fix the problem, we need to ensure that the Flask application does not run in debug mode in a production environment. The best way to achieve this is to use an environment variable to control the debug mode. This way, we can enable debug mode during development and disable it in production without changing the code.

We will modify the `app.run` call to check an environment variable (e.g., `FLASK_DEBUG`) to determine whether to enable debug mode. This change will be made in the `if __name__ == '__main__':` block.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
