### PR TITLE
Fix code scanning alert no. 6: SQL query built from user-controlled sources

### DIFF
--- a/db_app.py
+++ b/db_app.py
@@ -54,15 +54,12 @@ class UserResource(Resource):
 
 
        try:
-           # Directly incorporating user input into the SQL query
-           rawQueryString = f"SELECT * FROM user WHERE id = {id}"
-           query = text(rawQueryString)
+           # Use parameterized query to prevent SQL injection
+           query = text("SELECT * FROM user WHERE id = :id")
 
-
-           # Execute the vulnerable query
-           result = db.session.execute(query)
+           # Execute the safe query with parameter
+           result = db.session.execute(query, {'id': id})
            user = result.fetchall()
-
 
            if user:
                return user


### PR DESCRIPTION
Fixes [https://github.com/GitHub-PaloIT-Lab/excitement-day-examples/security/code-scanning/6](https://github.com/GitHub-PaloIT-Lab/excitement-day-examples/security/code-scanning/6)

To fix the problem, we should use parameterized queries provided by SQLAlchemy to safely include user input in the SQL query. This will ensure that the user input is properly escaped and prevent SQL injection attacks.

- Replace the raw SQL query construction with a parameterized query.
- Use SQLAlchemy's `text` function with bind parameters to safely include the `id` parameter in the query.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
